### PR TITLE
Add support for IDN

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     rspec-support (3.4.1)
     ruby-prof (0.15.9)
     safe_yaml (1.0.4)
+    simpleidn (0.0.7)
     slop (3.6.0)
     thor (0.19.1)
     vcr (3.0.3)
@@ -71,6 +72,7 @@ DEPENDENCIES
   rspec
   ruby-prof
   sendgrid_api!
+  simpleidn
   vcr
   webmock
 

--- a/lib/sendgrid_api/delivery_methods/sendgrid.rb
+++ b/lib/sendgrid_api/delivery_methods/sendgrid.rb
@@ -1,5 +1,6 @@
 begin
   require 'mail/check_delivery_params'
+  require 'simpleidn'
 rescue LoadError
 end
 
@@ -103,6 +104,22 @@ module Mail
     #
     def parse_email_address(email)
       Array(email).collect { |email| Mail::Address.new(email) }
+    rescue Mail::Field::ParseError => e
+      punycode_email(email)
     end
+
+    # convert email domain names containing unicode characters to punycode
+    # @param [String] email
+    # @return [Array] Mail::Address
+    #
+    def punycode_email(email)
+      Array(email).collect do |email|
+        email_part, display_name = email.split(/\<(.*?)\>/).reverse
+        email = Mail::Address.new(SimpleIDN.to_ascii(email_part))
+        email.tap{ |m| m.display_name = display_name.tr!('"','').strip!} if display_name
+        email
+      end
+    end
+
   end
 end

--- a/sendgrid_api.gemspec
+++ b/sendgrid_api.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "appraisal"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "simpleidn"
 
   s.add_runtime_dependency "mail"
   s.add_runtime_dependency "faraday_middleware"


### PR DESCRIPTION
- Adds support for unicode domain name chars
- Encodes display names by default, safe to non-unicode strings
- Converts unicode domain names to punycode to support IDN

PROD-907 #close
