### PR TITLE
Prod 1061 idn

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     sendgrid_api (1.2.0)
       faraday_middleware
       mail
+      simpleidn
 
 GEM
   remote: https://rubygems.org/
@@ -53,6 +54,7 @@ GEM
     rspec-support (3.4.1)
     ruby-prof (0.15.9)
     safe_yaml (1.0.4)
+    simpleidn (0.0.7)
     slop (3.6.0)
     thor (0.19.1)
     vcr (3.0.3)

--- a/lib/sendgrid_api/delivery_methods/sendgrid.rb
+++ b/lib/sendgrid_api/delivery_methods/sendgrid.rb
@@ -114,7 +114,7 @@ module Mail
     #
     def punycode_email(email)
       Array(email).collect do |email|
-        email_part, display_name = email.split(/\<(.*?)\>/).reverse
+        email_part, display_name = email.split(/\s*<(.+?)>\z/).reverse
         email = Mail::Address.new(SimpleIDN.to_ascii(email_part))
         email.tap{ |m| m.display_name = display_name.tr!('"','').strip!} if display_name
         email

--- a/lib/sendgrid_api/delivery_methods/sendgrid.rb
+++ b/lib/sendgrid_api/delivery_methods/sendgrid.rb
@@ -116,7 +116,9 @@ module Mail
       Array(email).collect do |email|
         email_part, display_name = email.split(/\s*<(.+?)>\z/).reverse
         email = Mail::Address.new(SimpleIDN.to_ascii(email_part))
-        email.tap{ |m| m.display_name = display_name.tr!('"','').strip!} if display_name
+        email.tap{ |m|
+          m.display_name = display_name[1..-2]
+        } if display_name && display_name.start_with?("\"")
         email
       end
     end

--- a/sendgrid_api.gemspec
+++ b/sendgrid_api.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true
 
+
   s.add_development_dependency "rspec"
   s.add_development_dependency "vcr"
   s.add_development_dependency "webmock"
@@ -28,4 +29,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "mail"
   s.add_runtime_dependency "faraday_middleware"
+  s.add_runtime_dependency "simpleidn"
 end

--- a/spec/delivery_methods/sendgrid_spec.rb
+++ b/spec/delivery_methods/sendgrid_spec.rb
@@ -234,7 +234,7 @@ module Mail
         end
 
         context "addresses with non-ascii domain name and non-ascii display name" do
-          let(:to) { '"andrè gïant" <to@àddress.com>' }
+          let(:to) { '"andrè "the" gïant" <to@àddress.com>' }
 
           it "should punycode the domain and send successfully" do
             expect(subject.client).to receive(:post).with(
@@ -242,7 +242,7 @@ module Mail
               nil,
               hash_including(
                 to:       ["xn--to@ddress-s1a.com"],
-                toname:   ["andrè gïant"],
+                toname:   ["andrè \"the\" gïant"],
                 from:     "from@address.com",
                 fromname: "José Publico"
               )

--- a/spec/delivery_methods/sendgrid_spec.rb
+++ b/spec/delivery_methods/sendgrid_spec.rb
@@ -110,7 +110,7 @@ module Mail
         end
       end
 
-      context "for encoded addresses" do
+      context "for encoded display name" do
         let(:from) { Mail::Address.new("from@address.com").tap { |m| m.display_name = "José Publico" }.encoded }
         let(:mail) {
           Mail.new(
@@ -122,23 +122,45 @@ module Mail
           end
         }
 
-        context "addresses with non-ascii string addresses" do
+        context "addresses with non-ascii display name" do
           let(:to) { '"José Publico" <to@address.com>' }
 
-          it "should raise an exception" do
-            expect{ subject.deliver!(mail) }.to raise_error Mail::Field::ParseError
+          it "should send successfully" do
+            expect(subject.client).to receive(:post).with(
+              "send",
+              nil,
+              hash_including(
+                to:       ["to@address.com"],
+                toname:   ["José Publico"],
+                from:     "from@address.com",
+                fromname: "José Publico"
+              )
+            ).and_return(success)
+
+            expect(subject.deliver!(mail)).to eq success
           end
         end
 
-        context "addresses with Mail::Address addresses" do
+        context "addresses with Mail::Address addresses non-ascii display name" do
           let(:to) { Mail::Address.new("to@address.com").tap { |m| m.display_name = "José Publico" } }
 
-          it "should raise an exception" do
-            expect{ subject.deliver!(mail) }.to raise_error Mail::Field::ParseError
+          it "should send successfully" do
+            expect(subject.client).to receive(:post).with(
+              "send",
+              nil,
+              hash_including(
+                to:       ["to@address.com"],
+                toname:   ["José Publico"],
+                from:     "from@address.com",
+                fromname: "José Publico"
+              )
+            ).and_return(success)
+
+            expect(subject.deliver!(mail)).to eq success
           end
         end
 
-        context "addresses with encoded string addresses" do
+        context "addresses with Mail::Address with encoded non-ascii display name" do
           let(:to) { Mail::Address.new("to@address.com").tap { |m| m.display_name = "José Publico" }.encoded }
 
           it "should send successfully" do
@@ -148,6 +170,79 @@ module Mail
               hash_including(
                 to:       ["to@address.com"],
                 toname:   ["José Publico"],
+                from:     "from@address.com",
+                fromname: "José Publico"
+              )
+            ).and_return(success)
+
+            expect(subject.deliver!(mail)).to eq success
+          end
+        end
+
+        context "addresses with non-ascii domain name" do
+          let(:to) { "jose@josépublic.com" }
+
+          it "should punycode the domain and send successfully" do
+            expect(subject.client).to receive(:post).with(
+              "send",
+              nil,
+              hash_including(
+                to:       ["xn--jose@jospublic-ikb.com"],
+                from:     "from@address.com",
+                fromname: "José Publico"
+              )
+            ).and_return(success)
+
+            expect(subject.deliver!(mail)).to eq success
+          end
+        end
+
+        context "addresses with non-ascii domain name and non-ascii local" do
+          let(:to) { "jöse@josépublic.com" }
+
+          it "should punycode the domain and send successfully" do
+            expect(subject.client).to receive(:post).with(
+              "send",
+              nil,
+              hash_including(
+                to:       ["xn--jse@jospublic-hhb2q.com"],
+                from:     "from@address.com",
+                fromname: "José Publico"
+              )
+            ).and_return(success)
+
+            expect(subject.deliver!(mail)).to eq success
+          end
+        end
+
+        context "addresses with an ascii domain name and non-ascii local" do
+          let(:to) { "jöse@josepublic.com" }
+
+          it "should punycode the domain and local and send successfully" do
+            expect(subject.client).to receive(:post).with(
+              "send",
+              nil,
+              hash_including(
+                to:       ["xn--jse@josepublic-vpb.com"],
+                from:     "from@address.com",
+                fromname: "José Publico"
+              )
+            ).and_return(success)
+
+            expect(subject.deliver!(mail)).to eq success
+          end
+        end
+
+        context "addresses with non-ascii domain name and non-ascii display name" do
+          let(:to) { '"andrè gïant" <to@àddress.com>' }
+
+          it "should punycode the domain and send successfully" do
+            expect(subject.client).to receive(:post).with(
+              "send",
+              nil,
+              hash_including(
+                to:       ["xn--to@ddress-s1a.com"],
+                toname:   ["andrè gïant"],
                 from:     "from@address.com",
                 fromname: "José Publico"
               )


### PR DESCRIPTION
- Adds support for unicode domain name chars
- Encodes display names by default, safe to non-unicode strings
- Converts unicode domain names to punycode to support IDN
  PROD-907 #close
