### PR TITLE
Add method to delete a sub user

### DIFF
--- a/lib/sendgrid_api/methods/sub_user.rb
+++ b/lib/sendgrid_api/methods/sub_user.rb
@@ -92,6 +92,12 @@ module SendgridApi
       access("disable", options)
     end
 
+    # Delete a subuser
+    #
+    def delete(options ={})
+      access("delete", options)
+    end
+
     # Enable website access to subuser
     #
     def website_enable(options = {})

--- a/spec/methods/sub_user_spec.rb
+++ b/spec/methods/sub_user_spec.rb
@@ -138,6 +138,12 @@ module SendgridApi
       end
     end
 
+    describe ".delete", vcr: true do
+      it "should delete the subuser account" do
+        expect(subject.delete(user).success?).to eq true
+      end
+    end
+
     describe ".setup_whitelabel", vcr: true do
       it "should update the subuser whitelabel domain" do
         expect(subject.setup_whitelabel(user.merge(mail_domain: "email.test.net")).success?).to eq true


### PR DESCRIPTION
Allows to delete a sub user via the api client.
WARNING 🔴  Deletion is irreversible, use with caution